### PR TITLE
chore: update tests setup

### DIFF
--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,9 +1,11 @@
 #!/usr/bin/env bats
 
-load '/usr/local/lib/bats/load.bash'
+setup() {
+  load "$BATS_PLUGIN_PATH/load.bash"
 
-# Uncomment the following line to debug stub failures
-# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+  # Uncomment to enable stub debugging
+  # export GIT_STUB_DEBUG=/dev/tty
+}
 
 @test "Fails when image-name not provided" {
   run "$PWD/hooks/command"


### PR DESCRIPTION
## Purpose 🎯 

Fix BATS testing

## Context 🧠 

Encountered this fix in adapting BATS testing from here to https://github.com/cultureamp/backstage-cdk-assets-buildkite-plugin/pull/1

Checkout and run of `docker compose run tests` failed with the following error

```
❯ docker compose run tests 
bats_load_safe: Could not find '/usr/local/lib/bats/load.bash'[.bash]
post-checkout.bats
 ✗ setup_file failed
   (in test file tests/post-checkout.bats, line 3)
     `load '/usr/local/lib/bats/load.bash'' failed with status 0
   bats warning: Executed 1 instead of expected 2 tests

2 tests, 1 failure, 1 not run
```

[Usage doco](https://github.com/buildkite-plugins/buildkite-plugin-tester#usage) of the Buildkite plugin tester image suggested this use of `${BATS_PLUGIN_PATH}` variable which works


