### PR TITLE
feat!: skip repository checkout by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,45 @@
 
 Provides a simple way to create a Docker image manifest from a series of images.
 
-## Example
+> ⚠️ **Note well:** by default, this plugin **disables checkout of the source
+> repository**. This should work well in most cases, as the operation does not
+> require any reference to the source.
+>
+> However, if other plugins are in use for whatever reason that do require the
+> source tree, set the `allow-checkout` parameter to `true`.
+
+## Basic example
 
 Add the following to your `pipeline.yml`:
 
 ```yml
 steps:
-  - command: ls
+  - label: ":docker: create manifest image"
     plugins:
-      - cultureamp/docker-manifest#v1.0.0:
+      - cultureamp/docker-manifest#v2.0.0:
           image-name: "full-image-name-and-tag"
           source-image-names:
             - "full-image-name-and-tag-1"
             - "full-image-name-and-tag-2"
+```
+
+The names can of course use variable interpolation (or matrix variables), as is
+standard in pipelines:
+
+## Example allowing repository checkout
+
+Note the use of the `allow-checkout` parameter:
+
+```yml
+steps:
+  - label: ":docker: create manifest image"
+    plugins:
+      - cultureamp/docker-manifest#v2.0.0:
+          image-name: "full-image-name-and-tag"
+          source-image-names:
+            - "full-image-name-and-tag-1"
+            - "full-image-name-and-tag-2"
+          allow-checkout: true
 ```
 
 ## Configuration
@@ -27,10 +53,21 @@ The full name of the manifest image to create, including the repository and labe
 
 The set of full image names to include in the manifest.
 
+### `allow-checkout` (Optional, boolean)
+
+**Default false.** When true, allows the current pipeline repository checkout to
+continue.
+
 ## Developing
 
 To run the tests:
 
 ```shell
 docker-compose run --rm tests
+```
+
+To check the plugin metadata:
+
+```shell
+docker-compose run --rm lint
 ```

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# shellcheck source=lib/shared.bash
+. "$DIR/../lib/shared.bash"
+
+
+function main(){
+  local allow_checkout; allow_checkout="$(plugin_read_config "ALLOW_CHECKOUT" "false")"
+
+  if [[ "${allow_checkout}" == "false" ]]; then
+    echo "~~~ :git: docker manifest plugin: Disabling local checkout"
+    echo "If this is required, pass 'allow-checkout: true' to the plugin config."
+
+    export BUILDKITE_REPO=""
+  fi
+}
+
+main "$@"

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite-plugins/buildkite-plugin-linter/master/lib/plugin-yaml-schema.yml
 name: Docker Manifest
 description: Creates a Docker manifest image, given a target image name and a set of source image names.
 author: https://github.com/cultureamp

--- a/plugin.yml
+++ b/plugin.yml
@@ -10,4 +10,5 @@ configuration:
     source-image-names:
       type: [string, array]
       minimum: 1
+  required: [ "image-name", "source-image-names" ]
   additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -10,5 +10,7 @@ configuration:
     source-image-names:
       type: [string, array]
       minimum: 1
+    allow-checkout:
+      type: boolean
   required: [ "image-name", "source-image-names" ]
   additionalProperties: false

--- a/tests/pre-checkout.bats
+++ b/tests/pre-checkout.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+setup() {
+  load "$BATS_PLUGIN_PATH/load.bash"
+
+  # Uncomment to enable stub debugging
+  # export GIT_STUB_DEBUG=/dev/tty
+}
+
+@test "Checkout is disabled by default" {
+  export BUILDKITE_REPO="test-repo-value"
+
+  source "$PWD/hooks/pre-checkout"
+
+  assert [ -z "${BUILDKITE_REPO}" ]
+}
+
+@test "Checkout is disabled when argument false" {
+  export BUILDKITE_REPO="test-repo-value"
+  export BUILDKITE_PLUGIN_DOCKER_MANIFEST_ALLOW_CHECKOUT="false"
+
+  source "$PWD/hooks/pre-checkout"
+
+  assert [ -z "${BUILDKITE_REPO}" ]
+}
+
+@test "Checkout is enabled when argument true" {
+  export BUILDKITE_REPO="test-repo-value"
+  export BUILDKITE_PLUGIN_DOCKER_MANIFEST_ALLOW_CHECKOUT="true"
+
+  source "$PWD/hooks/pre-checkout"
+
+  assert [ "${BUILDKITE_REPO}" == "test-repo-value" ]
+}


### PR DESCRIPTION
Since this plugin doesn't interact with the checkout at all, we can skip the repository checkout by default.

This behaviour can be opted out of using the `allow-checkout` parameter.

Checkout is skipped using the documented ability to change the `BUILDKITE_REPO` variable in the `pre-checkout` hook.